### PR TITLE
Fix some typos

### DIFF
--- a/TUT/STA130F24_TUT06_Oct25.ipynb
+++ b/TUT/STA130F24_TUT06_Oct25.ipynb
@@ -37,7 +37,7 @@
     "\n",
     "- **Predictor variable** $x_i$ is a **numeric variable**\n",
     "    > - Fow now we'll consider $x_i$ to be a **continuous** numeric variable, but this is not necessary, and we will consider versions of $x_i$ later\n",
-    "    > - **Predictor variable** $x_i$ can also be called a **explanatory**, **independent**, or **endogenous variable**, or a **covariate** or **feature** (which are the preferred terms in the statistics and machine learning domains, respectively)\n",
+    "    > - **Predictor variable** $x_i$ can also be called a **explanatory**, **independent**, or **exogenous variable**, or a **covariate** or **feature** (which are the preferred terms in the statistics and machine learning domains, respectively)\n",
     "    \n",
     "\n",
     "- **Intercept** $\\beta_0$ and **slope** $\\beta_1$ are the two **parameters** in the **simple linear regression model** \n",
@@ -183,7 +183,7 @@
     "\n",
     "   $$Y_i = \\beta_0 + \\beta_1 x_i + \\epsilon_i \\quad \\text{ where } \\quad \\epsilon_i \\sim \\mathcal N\\left(0, \\sigma^2\\right)$$\n",
     "   \n",
-    "   > This is done to incorporate **distribuitonal assumptions** that can be leveraged for **inference purposes** (of **estimation** and **hypothesis testing**)\n",
+    "   > This is done to incorporate **distributional assumptions** that can be leveraged for **inference purposes** (of **estimation** and **hypothesis testing**)\n",
     "\n",
     "2. Address some of the the first two assumptions associated with the above so-called **simple linear regression model** (with the remaining assumptions being \"beyond the scope\" of STA130)\n",
     "\n",
@@ -195,6 +195,12 @@
     "    > 4. And The $\\epsilon_i$ **errors** are **statistically independent** (so their values do not depend on each other)<br>\n",
     "\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15325b32",
+   "metadata": {},
+   "source": []
   },
   {
    "cell_type": "code",
@@ -6333,13 +6339,19 @@
    "id": "cf6f3d4e",
    "metadata": {},
    "source": [
-    "### Step 1: Students should come up with the standard form of the regression equation for $E[\\text{avg_ticket_price}] $ for both graphs\n",
+    "### Step 1: Students should come up with the standard form of the regression equation for $E[\\text{avg\\_ticket\\_price}]$ for both graphs\n",
     "### Step 2: Then, they should collectively try to find estimates for the parameters of the equations.\n",
     "\n",
     "- Re-emphasize here that in Step 1, they were talking about the idea of a linear model behind the two variables of the broadway dataset and in Step 2 they manually fit a linear model to the indicator and outcome variable.\n",
     "<br><br>\n",
     "- Discuss students' answers and confirm estimates of parameters by scrolling over the trendlines."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b7787030",
+   "metadata": {},
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Hey Scott, 

These are some of the typos I mentioned over coffee the other day...the one that really caught my eye was "endog" for $\mathbf{X}$'s. Seems like it should be exog if we are talking about the term favoured by the economist types (see statsmodels [here](https://www.statsmodels.org/dev/endog_exog.html)). 

Also under `The Linear Regression Model [20 minutes]`, I think it'd be more clear if conditional expectation was explicitly mentioned somewhere since it's good to understand that LR is a conditional means model. Cool stuff!